### PR TITLE
Add automated backend starting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+flake.nix

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 /target
-
-flake.nix

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -18,8 +18,7 @@ pub fn init_backend_from_name(name: &str) {
 }
 
 pub fn init_backend_auto() {
-    if env::var("WAYLAND_DISPLAY").is_ok() ||
-      env::var("DISPLAY").is_ok() {
+    if env::var("WAYLAND_DISPLAY").is_ok() || env::var("DISPLAY").is_ok() {
         init_backend_from_name("winit");
     } else {
         init_backend_from_name("udev");

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -18,7 +18,8 @@ pub fn init_backend_from_name(name: &str) {
 }
 
 pub fn init_backend_auto() {
-    if env::var("WAYLAND_DISPLAY").is_ok() {
+    if env::var("WAYLAND_DISPLAY").is_ok() ||
+      env::var("DISPLAY").is_ok() {
         init_backend_from_name("winit");
     } else {
         init_backend_from_name("udev");

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -13,7 +13,6 @@ pub fn init_backend_from_name(name: &str) {
         }
         unknown => {
             tracing::error!("Attempted to start unknown backend: {}", unknown);
-            return;
         }
     }
 }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,2 +1,27 @@
+use std::env;
+
 pub mod udev;
 pub mod winit;
+
+pub fn init_backend_from_name(name: &str) {
+    match name {
+        "udev" => {
+            udev::init_udev();
+        }
+        "winit" => {
+            winit::init_winit();
+        }
+        unknown => {
+            tracing::error!("Attempted to start unknown backend: {}", unknown);
+            return;
+        }
+    }
+}
+
+pub fn init_backend_auto() {
+    if env::var("WAYLAND_DISPLAY").is_ok() {
+        init_backend_from_name("winit");
+    } else {
+        init_backend_from_name("udev");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,14 +82,13 @@ fn main() {
         }
         Some(other) => {
             error!("Unknown backend: {}", other);
+            info!("Possible backends are:");
+            for line in POSSIBLE_BACKENDS {
+                println!("{}", line);
+            }
         }
         None => {
-            println!("USAGE: magma --backend");
-            println!();
-            println!("Possible backends are:");
-            for b in POSSIBLE_BACKENDS {
-                println!("\t{}", b);
-            }
+            backends::init_backend_auto();
         }
     }
 


### PR DESCRIPTION
I added a function that will automatically choose a backend to start if one has not been specified by the user

How it works:
    - If WAYLAND_DISPLAY is set, that indicates that a compositor is already running, so it starts with the winit backend
    - If not: it starts from the udev backend 