### PR TITLE
Nix flake tweaks

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,24 @@
+name: Nix Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  nix-build:
+    name: Nix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: Setup magic-nix-cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build
+        run: nix build .#magmawm

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1704152458,
-        "narHash": "sha256-DS+dGw7SKygIWf9w4eNBUZsK+4Ug27NwEWmn2tnbycg=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "88a2cd8166694ba0b6cb374700799cec53aef527",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -52,24 +34,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "dir": "lib",
-        "lastModified": 1703961334,
-        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1681358109,
@@ -88,7 +52,6 @@
     },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -34,22 +34,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
@@ -59,7 +43,9 @@
     "rust-overlay": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1704420966,

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,11 @@
 {
-
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
-  outputs = inputs@{ nixpkgs, flake-parts, rust-overlay, ... }:
+  outputs = inputs@{ self, nixpkgs, flake-parts, rust-overlay, ... }:
     flake-parts.lib.mkFlake
       {
         inherit inputs;
@@ -20,73 +19,32 @@
 
         perSystem = { system, ... }:
           let
+            inherit (pkgs) lib;
+
+            version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+
             pkgs = import nixpkgs {
               inherit system;
               overlays = [ (import rust-overlay) ];
             };
+
             rust-toolchain = "stable";
-            rust-package = pkgs.rust-bin."${rust-toolchain}".latest.default;
 
-            native-dependencies = with pkgs; [
-              pkg-config
-              makeWrapper
-            ];
-
-            dependencies = with pkgs; [
-              libglvnd
-              libseat
-              wayland
-              wayland-scanner
-              pkg-config
-              libdrm
-              systemdLibs # Contains libudev. DON'T PANIC: it won't install the whole init system
-              libxkbcommon
-              mesa
-              libinput
-              xorg.libX11 # Needed for xwayland to work
-              xorg.libXcursor
-              xorg.libXi
-            ];
-
-            # TODO: code this in a split file and import it
-            magmawm = pkgs.rustPlatform.buildRustPackage {
-              rust = rust-package;
-              pname = "magmawm";
-              version = "0.0.1";
-              src = ./.;
-              buildInputs = dependencies;
-              nativeBuildInputs = native-dependencies;
-
-              cargoLock = {
-                lockFile = ./Cargo.lock;
-                outputHashes = {
-                  "smithay-0.3.0" = "sha256-UQwYV3GOkZHEFyAMRMY46JiFXsdsjfSVHAHlA47ZAtI=";
-                  "smithay-drm-extras-0.1.0" = "sha256-2DrVZ4FiCmAr3DlUfnlb4c1tkcG8ydVHYMG5FUvCTrI=";
-                  "smithay-egui-0.1.0" = "sha256-FcSoKCwYk3okwQURiQlDUcfk9m/Ne6pSblGAzHDaVHg=";
-                };
-              };
-
-              postInstall = ''
-                wrapProgram $out/bin/magmawm --prefix LD_LIBRARY_PATH : "${pkgs.libglvnd}/lib"
-              '';
+            magmawm = pkgs.callPackage ./nix/magmawm.nix {
+              inherit pkgs lib rust-toolchain version;
             };
 
           in
           {
             devShells.default = pkgs.mkShell {
-              buildInputs = dependencies;
-              nativeBuildInputs = native-dependencies;
-
-              packages = [
-                rust-package
-              ];
-
+              inputsFrom = [ self.packages.${system}.magmawm ];
               shellHook = ''
                 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.libglvnd}/lib"
               '';
             };
 
-            packages.default = magmawm;
+            packages.default = self.packages.${system}.magmawm;
+            packages.magmawm = magmawm;
           };
       };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { self, nixpkgs, rust-overlay, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -7,82 +7,87 @@
   };
 
   outputs = inputs@{ nixpkgs, flake-parts, rust-overlay, ... }:
-    flake-parts.lib.mkFlake {
-      inherit inputs;
-    } {
-      systems = [
-        "x86_64-linux"
-	"i686-linux"
-	"aarch64-linux"
-      ];
-      perSystem = {config, system, ...}: let
-        pkgs = import nixpkgs { 
-	  inherit system; 
-	  overlays = [ (import rust-overlay) ];
-	};
-	rust-toolchain = "stable";
-	rust-package = pkgs.rust-bin."${rust-toolchain}".latest.default;
-	
-	native-dependencies = with pkgs; [
-           pkg-config
-	   makeWrapper
-	];
-	
-	dependencies = with pkgs; [
-	    libglvnd
-	    libseat
-	    wayland
-	    wayland-scanner
-	    pkg-config
-	    libdrm
-	    systemdLibs # Contains libudev. DON'T PANIC: it won't install the whole init system
-	    libxkbcommon
-	    mesa
-            libinput
-	    xorg.libX11 # Needed for xwayland to work
-	    xorg.libXcursor
-	    xorg.libXi
-	    
-	  ];
+    flake-parts.lib.mkFlake
+      {
+        inherit inputs;
+      }
+      {
+        systems = [
+          "x86_64-linux"
+          "i686-linux"
+          "aarch64-linux"
+        ];
 
-          # TODO: code this in a split file and import it
-	  magmawm = pkgs.rustPlatform.buildRustPackage {
-	    rust = rust-package;
-            pname = "magmawm";
-	    version = "0.0.1";
-	    src = ./.;
-	    buildInputs = dependencies;
-	    nativeBuildInputs = native-dependencies;
+        perSystem = { system, ... }:
+          let
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [ (import rust-overlay) ];
+            };
+            rust-toolchain = "stable";
+            rust-package = pkgs.rust-bin."${rust-toolchain}".latest.default;
 
-	    cargoLock = {
-              lockFile = ./Cargo.lock;
-	      outputHashes = {
-                "smithay-0.3.0" = "sha256-UQwYV3GOkZHEFyAMRMY46JiFXsdsjfSVHAHlA47ZAtI=";
-		"smithay-drm-extras-0.1.0" = "sha256-2DrVZ4FiCmAr3DlUfnlb4c1tkcG8ydVHYMG5FUvCTrI=";
-		"smithay-egui-0.1.0" = "sha256-FcSoKCwYk3okwQURiQlDUcfk9m/Ne6pSblGAzHDaVHg=";
-	      };
-	    };
+            native-dependencies = with pkgs; [
+              pkg-config
+              makeWrapper
+            ];
 
-	    postInstall = ''
-	      wrapProgram $out/bin/magmawm --prefix LD_LIBRARY_PATH : "${pkgs.libglvnd}/lib"
-	    '';
-	  };
+            dependencies = with pkgs; [
+              libglvnd
+              libseat
+              wayland
+              wayland-scanner
+              pkg-config
+              libdrm
+              systemdLibs # Contains libudev. DON'T PANIC: it won't install the whole init system
+              libxkbcommon
+              mesa
+              libinput
+              xorg.libX11 # Needed for xwayland to work
+              xorg.libXcursor
+              xorg.libXi
+            ];
 
-      in {
-	devShells.default = pkgs.mkShell {
-          buildInputs = dependencies;
-	  nativeBuildInputs = native-dependencies;
+            # TODO: code this in a split file and import it
+            magmawm = pkgs.rustPlatform.buildRustPackage {
+              rust = rust-package;
+              pname = "magmawm";
+              version = "0.0.1";
+              src = ./.;
+              buildInputs = dependencies;
+              nativeBuildInputs = native-dependencies;
 
-	  packages = [
-            rust-package
-	  ];
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+                outputHashes = {
+                  "smithay-0.3.0" = "sha256-UQwYV3GOkZHEFyAMRMY46JiFXsdsjfSVHAHlA47ZAtI=";
+                  "smithay-drm-extras-0.1.0" = "sha256-2DrVZ4FiCmAr3DlUfnlb4c1tkcG8ydVHYMG5FUvCTrI=";
+                  "smithay-egui-0.1.0" = "sha256-FcSoKCwYk3okwQURiQlDUcfk9m/Ne6pSblGAzHDaVHg=";
+                };
+              };
 
-	  shellHook = ''
-            export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.libglvnd}/lib"
-	  '';
-	};
-	packages.default = magmawm;
+              postInstall = ''
+                wrapProgram $out/bin/magmawm --prefix LD_LIBRARY_PATH : "${pkgs.libglvnd}/lib"
+              '';
+            };
+
+          in
+          {
+            devShells.default = pkgs.mkShell {
+              buildInputs = dependencies;
+              nativeBuildInputs = native-dependencies;
+
+              packages = [
+                rust-package
+              ];
+
+              shellHook = ''
+                export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.libglvnd}/lib"
+              '';
+            };
+
+            packages.default = magmawm;
+          };
       };
-    };
 }
 

--- a/nix/magmawm.nix
+++ b/nix/magmawm.nix
@@ -45,4 +45,11 @@ pkgs.rustPlatform.buildRustPackage {
   postInstall = ''
     wrapProgram $out/bin/magmawm --prefix LD_LIBRARY_PATH : "${pkgs.libglvnd}/lib"
   '';
+
+  meta = {
+    description = "A versatile and customizable Window Manager and Wayland Compositor";
+    homepage = "https://magmawm.org/";
+    license = lib.licenses.mit;
+    mainProgram = "magmawm";
+  };
 }

--- a/nix/magmawm.nix
+++ b/nix/magmawm.nix
@@ -1,0 +1,48 @@
+{ lib
+, pkgs
+, rust-toolchain
+, version
+, ...
+}:
+
+pkgs.rustPlatform.buildRustPackage {
+  inherit version;
+  pname = "magmawm";
+  src = lib.cleanSource ../.;
+
+  rust = pkgs.rust-bin."${rust-toolchain}".latest.default;
+
+  buildInputs = with pkgs; [
+    libdrm
+    libglvnd
+    libinput
+    libseat
+    libxkbcommon
+    mesa
+    pkg-config
+    systemdLibs # Contains libudev. DON'T PANIC: it won't install the whole init system
+    wayland
+    wayland-scanner
+    xorg.libX11 # Needed for xwayland to work
+    xorg.libXcursor
+    xorg.libXi
+  ];
+
+  nativeBuildInputs = with pkgs; [
+    makeWrapper
+    pkg-config
+  ];
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    outputHashes = {
+      "smithay-0.3.0" = "sha256-UQwYV3GOkZHEFyAMRMY46JiFXsdsjfSVHAHlA47ZAtI=";
+      "smithay-drm-extras-0.1.0" = "sha256-2DrVZ4FiCmAr3DlUfnlb4c1tkcG8ydVHYMG5FUvCTrI=";
+      "smithay-egui-0.1.0" = "sha256-FcSoKCwYk3okwQURiQlDUcfk9m/Ne6pSblGAzHDaVHg=";
+    };
+  };
+
+  postInstall = ''
+    wrapProgram $out/bin/magmawm --prefix LD_LIBRARY_PATH : "${pkgs.libglvnd}/lib"
+  '';
+}


### PR DESCRIPTION
I noticed while reading the recently merged flake that there were some formatting inconsistencies, and an outstanding `TODO` to move the package into it's own file.

This PR is broken into a few commits that achieve the following:

- Break the `magmawm` package into its own file
- Remove reliance on `flake-parts` to simplify flake
- Ensure `rust-overlay` follows this flake's nixpkgs instance
- Include a package overlay so people can more easily consume the package on their system
- Apply formatting with `nixpkgs-fmt`
- Adds `meta` section to package
- Read package version from `Cargo.toml`

Overall I think this will result in needing to change fewer things when bumping versions and adding/removing dependencies.

Happy to make any changes as necessary! :+1: 