### PR TITLE
Update udev.rs

### DIFF
--- a/src/backends/udev.rs
+++ b/src/backends/udev.rs
@@ -221,7 +221,7 @@ pub fn init_udev() {
                         .iter_mut()
                         .map(|(handle, backend)| (*handle, backend))
                     {
-                        backend.drm.activate();
+                        backend.drm.activate(true);
                         for (crtc, surface) in backend
                             .surfaces
                             .iter_mut()


### PR DESCRIPTION
I think it would be better if we pass `true` in order to let the library manage the drm activation.