### PR TITLE
Process spawning error message fix and refactor

### DIFF
--- a/src/backends/udev.rs
+++ b/src/backends/udev.rs
@@ -67,7 +67,10 @@ use crate::{
     delegate_screencopy_manager,
     protocols::screencopy::{frame::Screencopy, ScreencopyHandler, ScreencopyManagerState},
     state::{Backend, CalloopData, MagmaState, CONFIG},
-    utils::render::{border::BorderShader, CustomRenderElements},
+    utils::{
+        process,
+        render::{border::BorderShader, CustomRenderElements},
+    },
 };
 
 static CURSOR_DATA: &[u8] = include_bytes!("../../resources/cursor.rgba");
@@ -313,13 +316,7 @@ pub fn init_udev() {
     std::env::set_var("WAYLAND_DISPLAY", &calloopdata.state.socket_name);
 
     for command in &CONFIG.autostart {
-        if let Err(err) = std::process::Command::new("/bin/sh")
-            .arg("-c")
-            .arg(command)
-            .spawn()
-        {
-            info!("{} {} {}", err, "Failed to spawn \"{}\"", command);
-        }
+        process::spawn(command);
     }
 
     event_loop

--- a/src/backends/winit.rs
+++ b/src/backends/winit.rs
@@ -32,6 +32,8 @@ use smithay::{
 };
 use tracing::{info, warn};
 
+use crate::utils::process;
+
 pub struct WinitData {
     backend: WinitGraphicsBackend<GlowRenderer>,
     damage_tracker: OutputDamageTracker,
@@ -193,13 +195,7 @@ pub fn init_winit() {
         .unwrap();
 
     for command in &CONFIG.autostart {
-        if let Err(err) = std::process::Command::new("/bin/sh")
-            .arg("-c")
-            .arg(command)
-            .spawn()
-        {
-            info!("{} {} {}", err, "Failed to spawn \"{}\"", command);
-        }
+        process::spawn(command);
     }
 
     event_loop

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -21,6 +21,7 @@ use crate::{
     config::Action,
     state::{Backend, MagmaState, CONFIG},
     utils::focus::FocusTarget,
+    utils::process,
 };
 
 impl MagmaState<UdevData> {
@@ -357,13 +358,7 @@ impl<BackendData: Backend> MagmaState<BackendData> {
             }
             Action::ToggleWindowFloating => todo!(),
             Action::Spawn(command) => {
-                if let Err(err) = std::process::Command::new("/bin/sh")
-                    .arg("-c")
-                    .arg(command.clone())
-                    .spawn()
-                {
-                    info!("{} {} {}", err, "Failed to spawn \"{}\"", command);
-                }
+                process::spawn(&command);
             }
             Action::VTSwitch(_) => {
                 info!("VTSwitch is not used in Winit backend.")

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod binarytree;
 pub mod focus;
+pub mod process;
 pub mod render;
 pub mod tiling;
 pub mod workspace;

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -1,0 +1,12 @@
+use std::process::{Child, Command};
+use tracing::{debug, info};
+
+pub fn spawn(command: &str) -> Option<Child> {
+    debug!("Spawning '{command}'");
+    Command::new("/bin/sh")
+        .arg("-c")
+        .arg(command)
+        .spawn()
+        .map_err(|e| info!("Failed to spawn '{command}': {e}"))
+        .ok()
+}


### PR DESCRIPTION
* Fixes borked error message
* Consolidates process spawning into a single function in a new module called `process`
* Adds a debug log message when spawning a process

I figure there will be more code related to processes at some point (I imagine we'll want to track their PIDs so that we can kill them for instance) so a module is probably warranted.

I also imagine that it could be helpful to have a debug statement when launching a process so that when your config changes don't work as expected you can do a sanity check that the process is being spawned.