### PR TITLE
Fix winit on NixOS

### DIFF
--- a/src/backends/winit.rs
+++ b/src/backends/winit.rs
@@ -81,6 +81,9 @@ pub fn init_winit() {
 
     let display: Display<MagmaState<WinitData>> = Display::new().unwrap();
 
+    // nixos gets confused if WAYLAND_DISPLAY is already set
+    std::env::remove_var("WAYLAND_DISPLAY");
+
     let (mut backend, mut winit) = winit::init::<GlowRenderer>().unwrap();
 
     let mode = Mode {


### PR DESCRIPTION
NixOS gets confused if you launch a new wayland session and `WAYLAND_DISPLAY` is already set. So unset it.