### PR TITLE
Rework logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,16 +455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,15 +468,6 @@ name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
-
-[[package]]
-name = "deranged"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "dispatch"
@@ -864,12 +845,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a611371471e98973dbcab4e0ec66c31a10bc356eeb4d54a0e05eac8158fe38c"
 
 [[package]]
-name = "itoa"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,7 +999,6 @@ dependencies = [
  "smithay-drm-extras",
  "smithay-egui",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
  "xdg",
 ]
@@ -1301,12 +1275,6 @@ dependencies = [
  "tracing",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1744,35 +1712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
-dependencies = [
- "deranged",
- "itoa",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
-dependencies = [
- "time-core",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,18 +1737,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
-dependencies = [
- "crossbeam-channel",
- "thiserror",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-tracing-appender = "0.2"
 chrono = "0.4.24"
 backtrace = "0.3.67"
 smithay-drm-extras = { git = "https://github.com/Smithay/smithay.git"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,13 @@
-use std::{fs::File, panic, thread};
+use std::{panic, thread};
 
 use backtrace::Backtrace;
-use chrono::Local;
 use clap::{Parser, ValueEnum};
 use tracing::{error, info};
-use tracing_subscriber::{
-    filter::{Directive, EnvFilter, LevelFilter},
-    layer::SubscriberExt,
-    util::SubscriberInitExt,
-    Layer,
-};
 
-use crate::backends::{udev, winit};
+use crate::{
+    backends::{udev, winit},
+    utils::log::init_logs,
+};
 
 mod backends;
 mod config;
@@ -43,52 +39,9 @@ enum Backend {
 }
 
 fn main() {
-    // TODO: maybe make these Paths to begin with?
-    let log_dir = format!(
-        "{}/.local/share/MagmaWM/",
-        std::env::var("HOME").expect("this should always be set")
-    );
-    let log_file_name = format!("magma_{}.log", Local::now().format("%Y-%m-%d_%H:%M:%S"));
-    let log_file_path = format!("{log_dir}/{log_file_name}");
-    let log_link_path = format!("{log_dir}/latest.log");
-
-    // create a new log file and symlink latest.log to it
-    let log_file = File::create(&log_file_path).expect("Unable to create log file");
-    // delete latest.log if it already exists
-    if std::path::Path::new(&log_link_path).exists() {
-        std::fs::remove_file(&log_link_path)
-            .unwrap_or_else(|_| panic!("Unable to remove {log_link_path}"));
-    }
-    std::os::unix::fs::symlink(&log_file_path, log_link_path).expect("Unable to symlink log file");
-
-    fn make_filter<S: AsRef<str>>(log_level: Option<S>, default: &Directive) -> EnvFilter {
-        // filter using the --log flag if passed, otherwise use RUST_LOG, ignoring invalid strings
-        match log_level {
-            Some(log_level) => EnvFilter::builder()
-                .with_default_directive(default.clone())
-                .parse_lossy(log_level),
-            None => EnvFilter::builder()
-                .with_default_directive(default.clone())
-                .from_env_lossy(),
-        }
-    }
-
     let args = Args::parse();
 
-    let default = LevelFilter::INFO.into();
-
-    let file_layer = tracing_subscriber::fmt::layer()
-        .with_ansi(false)
-        .with_writer(log_file)
-        .with_filter(make_filter(args.log.as_ref(), &default));
-    let stderr_layer = tracing_subscriber::fmt::layer()
-        .with_writer(std::io::stderr)
-        .with_filter(make_filter(args.log.as_ref(), &default));
-
-    tracing_subscriber::registry()
-        .with(file_layer)
-        .with(stderr_layer)
-        .init();
+    init_logs(args.log);
 
     panic::set_hook(Box::new(move |info| {
         let backtrace = Backtrace::new();

--- a/src/utils/log.rs
+++ b/src/utils/log.rs
@@ -1,0 +1,81 @@
+use chrono::Local;
+use std::{
+    fs,
+    fs::File,
+    os,
+    path::{Path, PathBuf},
+};
+use tracing_subscriber::{
+    filter::{EnvFilter, LevelFilter},
+    layer::SubscriberExt,
+    util::SubscriberInitExt,
+    Layer,
+};
+
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::INFO;
+
+/// Initialize logging for the application.
+///
+/// Log files are in `~/.local/share/MagmaWM`
+/// * Creates a timestamped log file: `magma_YYYY-MM-DD_HH:MM:SS.log`.
+/// * Symlinks `latest.log` to the latest timestamped log file.
+///
+/// Logs are also printed to `stderr`.
+///
+/// Log levels are set by the following, in order of precedence:
+/// * `log_level`
+/// * The `RUST_LOG` environment variable
+/// * `DEFAULT_LOG_LEVEL`
+///
+/// **Note:** Malformed values will result in no logs.
+///
+/// # Parameters
+///
+/// * `log_level`: The primary log level setting. Intended to be the value of the `--log=LOG_LEVEL`
+/// flag.
+pub fn init_logs<S: AsRef<str>>(log_level: Option<S>) {
+    let home_dir = std::env::var("HOME").expect("$HOME is not set");
+    let log_dir = PathBuf::from(home_dir).join(".local/share/MagmaWM/");
+
+    let log_file_name = format!("magma_{}.log", Local::now().format("%Y-%m-%d_%H:%M:%S"));
+    let log_file_path = log_dir.join(log_file_name);
+    let log_link_path = log_dir.join("latest.log");
+
+    // create a new log file and symlink latest.log to it
+    let log_file = File::create(&log_file_path).expect("Unable to create log file");
+    // delete latest.log if it already exists
+    if Path::new(&log_link_path).exists() {
+        fs::remove_file(&log_link_path)
+            .unwrap_or_else(|_| panic!("Unable to remove {}", log_link_path.to_string_lossy()));
+    }
+    os::unix::fs::symlink(&log_file_path, log_link_path).expect("Unable to symlink log file");
+
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_ansi(false)
+        .with_writer(log_file)
+        .with_filter(filter(log_level.as_ref()));
+    let stderr_layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_filter(filter(log_level));
+
+    tracing_subscriber::registry()
+        .with(file_layer)
+        .with(stderr_layer)
+        .init();
+}
+
+/// Creates a filter with the value of `log_level` if it is `Some`, or the `RUST_LOG` environment
+/// variable if it is `None`, or `DEFAULT_LOG_LEVEL` if neither of the previous have a value.
+///
+/// **Note:** Malformed values will cause no logging at all.
+///
+/// This helper method exists to reduce repetion because `EnvFilter` does not implement `Clone`.
+fn filter<S: AsRef<str>>(log_level: Option<S>) -> EnvFilter {
+    // lossy means if the value is malformed, filter out everything
+    match log_level {
+        Some(log_level) => EnvFilter::builder().parse_lossy(log_level),
+        None => EnvFilter::builder()
+            .with_default_directive(DEFAULT_LOG_LEVEL.into())
+            .from_env_lossy(),
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod binarytree;
 pub mod focus;
+pub mod log;
 pub mod process;
 pub mod render;
 pub mod tiling;


### PR DESCRIPTION
* Only print ANSI color codes in the terminal, not in the log files
* Move logging code into it's own module
* Remove `tracing_appender` since we weren't using its rolling logs functionality