### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
  "smithay",
  "smithay-drm-extras",
  "smithay-egui",
+ "thiserror",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1326,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.71"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -1363,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1691,9 +1692,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.43"
+version = "2.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1715,18 +1716,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.52"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a48fd946b02c0a526b2e9481c8e2a17755e47039164a86c4070446e3a4614d"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.52"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ colors-transform = "0.2.11"
 egui = { version = "0.23", optional = true }
 egui_plot = { version = "0.23", optional = true }
 clap = { version = "4.5.4", features = ["derive"] }
+thiserror = "1.0.58"
 
 [dependencies.smithay]
 git = "https://github.com/Smithay/smithay.git"

--- a/src/backends/udev.rs
+++ b/src/backends/udev.rs
@@ -622,7 +622,8 @@ impl MagmaState<UdevData> {
                     None,
                 )
                 .unwrap();
-                BorderShader::init(renderer.as_mut());
+                // TODO: Propagate this error
+                BorderShader::init(renderer.as_mut()).unwrap();
                 let surface = Surface {
                     _device_id: node,
                     _render_node: device.render_node,
@@ -938,7 +939,8 @@ impl MagmaState<UdevData> {
                 |_, _| Some(output.clone()),
             );
         });
-        BorderShader::cleanup(renderer.as_mut());
+        // TODO: Propagate this error
+        BorderShader::cleanup(renderer.as_mut()).unwrap();
         result
     }
 }

--- a/src/backends/winit.rs
+++ b/src/backends/winit.rs
@@ -294,7 +294,12 @@ pub fn winit_dispatch(
             }),
     );
 
-    renderelements.extend(workspace.render_elements(winitdata.backend.renderer()));
+    renderelements.extend(
+        workspace
+            .render_elements(winitdata.backend.renderer())
+            // TODO: Propagate this error
+            .unwrap(),
+    );
 
     renderelements.extend(
         lower

--- a/src/backends/winit.rs
+++ b/src/backends/winit.rs
@@ -174,7 +174,8 @@ pub fn init_winit() {
     };
 
     let state = &mut data.state;
-    BorderShader::init(state.backend_data.backend.renderer());
+    // TODO: Propagate this error
+    BorderShader::init(state.backend_data.backend.renderer()).unwrap();
     // map output to every workspace
     for workspace in state.workspaces.iter() {
         workspace.add_output(output.clone());
@@ -342,5 +343,6 @@ pub fn winit_dispatch(
     workspace.windows().for_each(|e| e.refresh());
     data.display_handle.flush_clients().unwrap();
     state.popup_manager.cleanup();
-    BorderShader::cleanup(winitdata.backend.renderer());
+    // TODO: Propagate this error
+    BorderShader::cleanup(winitdata.backend.renderer()).unwrap();
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,12 @@
+use smithay::backend::renderer::gles::GlesError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Shader compilation error: {0}")]
+    ShaderCompilationError(#[from] GlesError),
+    #[error("Border shader not initialized")]
+    BorderShaderNotInitialized,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use smithay::backend::renderer::gles::GlesError;
+use smithay::backend::{renderer::gles::GlesError, SwapBuffersError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -7,6 +7,8 @@ pub enum Error {
     ShaderCompilationError(#[from] GlesError),
     #[error("Border shader not initialized")]
     BorderShaderNotInitialized,
+    #[error("Swap buffers error: {0}")]
+    SwapBuffersError(#[from] SwapBuffersError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod backends;
 mod config;
 #[cfg(feature = "debug")]
 mod debug;
+mod error;
 mod handlers;
 mod protocols;
 mod state;

--- a/src/utils/render/border.rs
+++ b/src/utils/render/border.rs
@@ -61,13 +61,8 @@ impl BorderShader {
             .insert_if_missing(|| BorderShaderElements(RefCell::new(HashMap::new())));
         Ok(())
     }
-    pub fn get(renderer: &GlowRenderer) -> Result<&BorderShader> {
-        let shader = renderer
-            .egl_context()
-            .user_data()
-            .get::<BorderShader>()
-            .ok_or(Error::BorderShaderNotInitialized)?;
-        Ok(shader)
+    pub fn get(renderer: &GlowRenderer) -> Option<&BorderShader> {
+        renderer.egl_context().user_data().get::<BorderShader>()
     }
     pub fn element(
         renderer: &mut GlowRenderer,
@@ -98,7 +93,10 @@ impl BorderShader {
             let gradient_direction = [angle.cos(), angle.sin()];
             let elem = if CONFIG.borders.radius > 0.0 {
                 PixelShaderElement::new(
-                    Self::get(renderer)?.rounded.clone(),
+                    Self::get(renderer)
+                        .ok_or(Error::BorderShaderNotInitialized)?
+                        .rounded
+                        .clone(),
                     geo,
                     None,
                     1.0,
@@ -120,7 +118,10 @@ impl BorderShader {
                 )
             } else {
                 PixelShaderElement::new(
-                    Self::get(renderer)?.default.clone(),
+                    Self::get(renderer)
+                        .ok_or(Error::BorderShaderNotInitialized)?
+                        .default
+                        .clone(),
                     geo,
                     None,
                     1.0,

--- a/src/utils/render/border.rs
+++ b/src/utils/render/border.rs
@@ -13,7 +13,10 @@ use smithay::{
     utils::{IsAlive, Logical, Point, Rectangle, Size},
 };
 
-use crate::state::CONFIG;
+use crate::{
+    error::{Error, Result},
+    state::CONFIG,
+};
 
 const ROUNDED_BORDER_FRAG: &str = include_str!("shaders/rounded_borders.frag");
 const BORDER_FRAG: &str = include_str!("shaders/borders.frag");
@@ -25,33 +28,29 @@ pub struct BorderShader {
 struct BorderShaderElements(RefCell<HashMap<Window, PixelShaderElement>>);
 
 impl BorderShader {
-    pub fn init(renderer: &mut GlowRenderer) {
+    pub fn init(renderer: &mut GlowRenderer) -> Result<()> {
         let renderer: &mut GlesRenderer = renderer.borrow_mut();
-        let rounded = renderer
-            .compile_custom_pixel_shader(
-                ROUNDED_BORDER_FRAG,
-                &[
-                    UniformName::new("startColor", UniformType::_3f),
-                    UniformName::new("endColor", UniformType::_3f),
-                    UniformName::new("thickness", UniformType::_1f),
-                    UniformName::new("halfThickness", UniformType::_1f),
-                    UniformName::new("radius", UniformType::_1f),
-                    UniformName::new("gradientDirection", UniformType::_2f),
-                ],
-            )
-            .unwrap();
-        let default = renderer
-            .compile_custom_pixel_shader(
-                BORDER_FRAG,
-                &[
-                    UniformName::new("startColor", UniformType::_3f),
-                    UniformName::new("endColor", UniformType::_3f),
-                    UniformName::new("thickness", UniformType::_1f),
-                    UniformName::new("halfThickness", UniformType::_1f),
-                    UniformName::new("gradientDirection", UniformType::_2f),
-                ],
-            )
-            .unwrap();
+        let rounded = renderer.compile_custom_pixel_shader(
+            ROUNDED_BORDER_FRAG,
+            &[
+                UniformName::new("startColor", UniformType::_3f),
+                UniformName::new("endColor", UniformType::_3f),
+                UniformName::new("thickness", UniformType::_1f),
+                UniformName::new("halfThickness", UniformType::_1f),
+                UniformName::new("radius", UniformType::_1f),
+                UniformName::new("gradientDirection", UniformType::_2f),
+            ],
+        )?;
+        let default = renderer.compile_custom_pixel_shader(
+            BORDER_FRAG,
+            &[
+                UniformName::new("startColor", UniformType::_3f),
+                UniformName::new("endColor", UniformType::_3f),
+                UniformName::new("thickness", UniformType::_1f),
+                UniformName::new("halfThickness", UniformType::_1f),
+                UniformName::new("gradientDirection", UniformType::_2f),
+            ],
+        )?;
         renderer
             .egl_context()
             .user_data()
@@ -60,19 +59,21 @@ impl BorderShader {
             .egl_context()
             .user_data()
             .insert_if_missing(|| BorderShaderElements(RefCell::new(HashMap::new())));
+        Ok(())
     }
-    pub fn get(renderer: &GlowRenderer) -> &BorderShader {
-        renderer
+    pub fn get(renderer: &GlowRenderer) -> Result<&BorderShader> {
+        let shader = renderer
             .egl_context()
             .user_data()
             .get::<BorderShader>()
-            .expect("Border Shader not initialized")
+            .ok_or(Error::BorderShaderNotInitialized)?;
+        Ok(shader)
     }
     pub fn element(
         renderer: &mut GlowRenderer,
         window: &Window,
         loc: Point<i32, Logical>,
-    ) -> PixelShaderElement {
+    ) -> Result<PixelShaderElement> {
         let thickness: f32 = CONFIG.borders.thickness as f32;
         let thickness_loc = (thickness as i32, thickness as i32);
         let thickness_size = ((thickness * 2.0) as i32, (thickness * 2.0) as i32);
@@ -84,10 +85,10 @@ impl BorderShader {
             .egl_context()
             .user_data()
             .get::<BorderShaderElements>()
-            .expect("Border Shader not initialized")
+            .ok_or(Error::BorderShaderNotInitialized)?
             .0
             .borrow_mut();
-        if let Some(elem) = elements.get_mut(window) {
+        Ok(if let Some(elem) = elements.get_mut(window) {
             if elem.geometry(1.0.into()).to_logical(1) != geo {
                 elem.resize(geo, None);
             }
@@ -97,7 +98,7 @@ impl BorderShader {
             let gradient_direction = [angle.cos(), angle.sin()];
             let elem = if CONFIG.borders.radius > 0.0 {
                 PixelShaderElement::new(
-                    Self::get(renderer).rounded.clone(),
+                    Self::get(renderer)?.rounded.clone(),
                     geo,
                     None,
                     1.0,
@@ -119,7 +120,7 @@ impl BorderShader {
                 )
             } else {
                 PixelShaderElement::new(
-                    Self::get(renderer).default.clone(),
+                    Self::get(renderer)?.default.clone(),
                     geo,
                     None,
                     1.0,
@@ -141,16 +142,16 @@ impl BorderShader {
             };
             elements.insert(window.clone(), elem.clone());
             elem
-        }
+        })
     }
-    pub fn cleanup(renderer: &mut GlowRenderer) {
+    pub fn cleanup(renderer: &mut GlowRenderer) -> Result<()> {
         let elements = &mut renderer
             .egl_context()
             .user_data()
             .get::<BorderShaderElements>()
-            .expect("Border Shader not initialized")
+            .ok_or(Error::BorderShaderNotInitialized)?
             .0
             .borrow_mut();
-        elements.retain(|w, _| w.alive())
+        Ok(elements.retain(|w, _| w.alive()))
     }
 }

--- a/src/utils/workspace.rs
+++ b/src/utils/workspace.rs
@@ -102,11 +102,15 @@ impl Workspace {
         for element in &self.windows {
             let window = &element.borrow().window;
             if CONFIG.borders.thickness > 0 {
-                render_elements.push(C::from(BorderShader::element(
-                    renderer.glow_renderer_mut(),
-                    window,
-                    element.borrow().rec.loc,
-                )));
+                render_elements.push(C::from(
+                    BorderShader::element(
+                        renderer.glow_renderer_mut(),
+                        window,
+                        element.borrow().rec.loc,
+                    )
+                    // TODO: Propagate this error
+                    .unwrap(),
+                ));
             }
             render_elements.append(&mut window.render_elements(
                 renderer,

--- a/src/utils/workspace.rs
+++ b/src/utils/workspace.rs
@@ -14,7 +14,7 @@ use smithay::{
     utils::{Logical, Point, Rectangle, Scale, Transform},
 };
 
-use crate::state::CONFIG;
+use crate::{error::Result, state::CONFIG};
 
 use super::{
     binarytree::BinaryTree,
@@ -94,7 +94,7 @@ impl Workspace {
     >(
         &self,
         renderer: &mut R,
-    ) -> Vec<C>
+    ) -> Result<Vec<C>>
     where
         <R as Renderer>::TextureId: Texture + 'static,
     {
@@ -102,15 +102,11 @@ impl Workspace {
         for element in &self.windows {
             let window = &element.borrow().window;
             if CONFIG.borders.thickness > 0 {
-                render_elements.push(C::from(
-                    BorderShader::element(
-                        renderer.glow_renderer_mut(),
-                        window,
-                        element.borrow().rec.loc,
-                    )
-                    // TODO: Propagate this error
-                    .unwrap(),
-                ));
+                render_elements.push(C::from(BorderShader::element(
+                    renderer.glow_renderer_mut(),
+                    window,
+                    element.borrow().rec.loc,
+                )?));
             }
             render_elements.append(&mut window.render_elements(
                 renderer,
@@ -119,7 +115,7 @@ impl Workspace {
                 1.0,
             ));
         }
-        render_elements
+        Ok(render_elements)
     }
 
     pub fn outputs(&self) -> impl Iterator<Item = &Output> {


### PR DESCRIPTION
The goal of this PR is to reduce the number of panics, by returning `Result`s wherever feasible.

Here is the current state of things:
* [ ] src/backends/udev.rs (-2/47)
* [ ] src/backends/winit.rs (-3/13)
* [x] src/config/mod.rs (0/9) - (9/9 exempted[^1])
* [ ] src/debug.rs (0/5)
* [ ] src/handlers/input.rs (0/10)
* [ ] src/handlers/mod.rs (0/3)
* [ ] src/handlers/xdg_shell.rs (0/10)
* [ ] src/protocols/screencopy/frame.rs (0/1)
* [ ] src/protocols/screencopy/mod.rs (0/3)
* [ ] src/state.rs (0/10)
* [ ] src/utils/focus.rs (0/1)
* [ ] src/utils/log.rs (0/3)
* [x] src/utils/render/border.rs (5/5)
* [ ] src/utils/tiling.rs (0/3)

[^1]: None of the panics in the `config` module could reasonably be recovered from, so returning them as errors is pointless.