### PR TITLE
Fix linking to libwayland and libEGL on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,6 @@
       overlays.default = final: _prev:
         let
           version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
-          
         in
         {
           magmawm = final.callPackage ./magmawm.nix {
@@ -48,13 +47,13 @@
           default = pkgs.mkShell {
             name = "magmawm";
             NIX_CONFIG = "experimental-features = nix-command flakes";
+            # Force linking to libEGL and libwayland-client
+            RUSTFLAGS = "-lEGL -lwayland-client";
+            LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.libglvnd}/lib";
             inputsFrom = [ self.packages.${system}.magmawm ];
             nativeBuildInputs = [
               pkgs.rust-bin."${rust-toolchain}".latest.default
             ];
-            shellHook = ''
-              export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.libglvnd}/lib"
-            '';
           };
         });
     };

--- a/magmawm.nix
+++ b/magmawm.nix
@@ -1,6 +1,5 @@
 { lib
 , pkgs
-, rust-toolchain
 , version
 , ...
 }:


### PR DESCRIPTION
Inspiration taken from the [`cosmic-comp` package in `nixpkgs`][1].

Also did some minor cleanup:
* Removed an unused import
* Removed a blank line
* Simplified export of `LD_LIBRARY_PATH`

[1]: https://github.com/NixOS/nixpkgs/blob/2230a20f2b5a14f2db3d7f13a2dc3c22517e790b/pkgs/by-name/co/cosmic-comp/package.nix#L64